### PR TITLE
fix: MP1 Plugin - load language files even if a non-default MP data folder is used

### DIFF
--- a/AtmoLight.MediaPortal1/Settings.cs
+++ b/AtmoLight.MediaPortal1/Settings.cs
@@ -206,7 +206,7 @@ namespace AtmoLight
           effectMPExit = (ContentEffect)Enum.Parse(typeof(ContentEffect), reader.GetValueAsString("atmolight", "effectMPExit", "LEDsDisabled"));
         }
 
-        currentLanguageFile = reader.GetValueAsString("atmolight", "CurrentLanguageFile", Win32API.GetSpecialFolder(Win32API.CSIDL.CSIDL_COMMON_APPDATA) + "\\Team MediaPortal\\MediaPortal\\language\\AtmoLight\\en.xml");
+        currentLanguageFile = reader.GetValueAsString("atmolight", "CurrentLanguageFile", currentLanguageFile = MediaPortal.Configuration.Config.GetFolder(MediaPortal.Configuration.Config.Dir.Language) + @"\AtmoLight\en.xml");
         if (currentLanguageFile.Substring(currentLanguageFile.Length - 3, 3).ToLower() == "lng")
         {
           int lastBackslash = currentLanguageFile.LastIndexOf("\\") + 1;
@@ -215,17 +215,17 @@ namespace AtmoLight
           switch (currentLanguageFile.Substring(lastBackslash, lastDot - lastBackslash))
           {
             case "GermanDE":
-              currentLanguageFile = Win32API.GetSpecialFolder(Win32API.CSIDL.CSIDL_COMMON_APPDATA) + "\\Team MediaPortal\\MediaPortal\\language\\AtmoLight\\de.xml";
+              currentLanguageFile = MediaPortal.Configuration.Config.GetFolder(MediaPortal.Configuration.Config.Dir.Language) + @"\AtmoLight\de.xml";
               break;
             case "DutchNL":
-              currentLanguageFile = Win32API.GetSpecialFolder(Win32API.CSIDL.CSIDL_COMMON_APPDATA) + "\\Team MediaPortal\\MediaPortal\\language\\AtmoLight\\nl.xml";
+              currentLanguageFile = MediaPortal.Configuration.Config.GetFolder(MediaPortal.Configuration.Config.Dir.Language) + @"\AtmoLight\nl.xml";
               break;
             case "FrenchFR":
-              currentLanguageFile = Win32API.GetSpecialFolder(Win32API.CSIDL.CSIDL_COMMON_APPDATA) + "\\Team MediaPortal\\MediaPortal\\language\\AtmoLight\\fr.xml";
+              currentLanguageFile = MediaPortal.Configuration.Config.GetFolder(MediaPortal.Configuration.Config.Dir.Language) + @"\AtmoLight\fr.xml";
               break;
             default:
             case "EnglishUS":
-              currentLanguageFile = Win32API.GetSpecialFolder(Win32API.CSIDL.CSIDL_COMMON_APPDATA) + "\\Team MediaPortal\\MediaPortal\\language\\AtmoLight\\en.xml";
+              currentLanguageFile = MediaPortal.Configuration.Config.GetFolder(MediaPortal.Configuration.Config.Dir.Language) + @"\AtmoLight\en.xml";
               break;
           }
         }

--- a/AtmoLight.MediaPortal1/Settings.cs
+++ b/AtmoLight.MediaPortal1/Settings.cs
@@ -3,6 +3,7 @@ using MediaPortal.Profile;
 using System.Globalization;
 using System.Collections.Generic;
 using System.Text;
+using System.IO;
 
 namespace AtmoLight
 {
@@ -206,7 +207,7 @@ namespace AtmoLight
           effectMPExit = (ContentEffect)Enum.Parse(typeof(ContentEffect), reader.GetValueAsString("atmolight", "effectMPExit", "LEDsDisabled"));
         }
 
-        currentLanguageFile = reader.GetValueAsString("atmolight", "CurrentLanguageFile", currentLanguageFile = MediaPortal.Configuration.Config.GetFolder(MediaPortal.Configuration.Config.Dir.Language) + @"\AtmoLight\en.xml");
+        currentLanguageFile = reader.GetValueAsString("atmolight", "CurrentLanguageFile", currentLanguageFile = Path.Combine(MediaPortal.Configuration.Config.GetFolder(MediaPortal.Configuration.Config.Dir.Language), @"\AtmoLight\en.xml"));
         if (currentLanguageFile.Substring(currentLanguageFile.Length - 3, 3).ToLower() == "lng")
         {
           int lastBackslash = currentLanguageFile.LastIndexOf("\\") + 1;
@@ -215,17 +216,17 @@ namespace AtmoLight
           switch (currentLanguageFile.Substring(lastBackslash, lastDot - lastBackslash))
           {
             case "GermanDE":
-              currentLanguageFile = MediaPortal.Configuration.Config.GetFolder(MediaPortal.Configuration.Config.Dir.Language) + @"\AtmoLight\de.xml";
+              currentLanguageFile = Path.Combine(MediaPortal.Configuration.Config.GetFolder(MediaPortal.Configuration.Config.Dir.Language), @"\AtmoLight\de.xml");
               break;
             case "DutchNL":
-              currentLanguageFile = MediaPortal.Configuration.Config.GetFolder(MediaPortal.Configuration.Config.Dir.Language) + @"\AtmoLight\nl.xml";
+              currentLanguageFile = Path.Combine(MediaPortal.Configuration.Config.GetFolder(MediaPortal.Configuration.Config.Dir.Language), @"\AtmoLight\nl.xml");
               break;
             case "FrenchFR":
-              currentLanguageFile = MediaPortal.Configuration.Config.GetFolder(MediaPortal.Configuration.Config.Dir.Language) + @"\AtmoLight\fr.xml";
+              currentLanguageFile = Path.Combine(MediaPortal.Configuration.Config.GetFolder(MediaPortal.Configuration.Config.Dir.Language), @"\AtmoLight\fr.xml");
               break;
             default:
             case "EnglishUS":
-              currentLanguageFile = MediaPortal.Configuration.Config.GetFolder(MediaPortal.Configuration.Config.Dir.Language) + @"\AtmoLight\en.xml";
+              currentLanguageFile = Path.Combine(MediaPortal.Configuration.Config.GetFolder(MediaPortal.Configuration.Config.Dir.Language), @"\AtmoLight\en.xml");
               break;
           }
         }


### PR DESCRIPTION
Before this fix it was not possible to have MediaPortal data folder at a
user specified location, only the default was working. The plugin was
throwing a FileNotFoundException when trying to open the plugin
settings.
