### PR TITLE
fix: Boblight "get lights" command is missing \n

### DIFF
--- a/AtmoLight.Core/Targets/Boblight/BoblightHandler.cs
+++ b/AtmoLight.Core/Targets/Boblight/BoblightHandler.cs
@@ -261,7 +261,7 @@ namespace AtmoLight
             return false;
           }
 
-          string lightsMessage = SendCommand("get lights", true);
+          string lightsMessage = SendCommand("get lights\n", true);
           if (string.IsNullOrEmpty(lightsMessage))
           {
             return false;


### PR DESCRIPTION
Without the \n the command doesn't get registered by
boblightd and nothing happens.
